### PR TITLE
Add Neo4j integration hooks

### DIFF
--- a/src/app/api/knowledge-graph/route.ts
+++ b/src/app/api/knowledge-graph/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+import { getKnowledgeGraph } from '../../../lib/knowledge-graph'
+
+export async function GET() {
+  try {
+    const kg = getKnowledgeGraph()
+    await kg.initialize()
+    const sessions = await kg.getSessions()
+    return NextResponse.json({ sessions })
+  } catch (err) {
+    console.error('KG query failed', err)
+    return NextResponse.json({ error: 'Failed to query knowledge graph' }, { status: 500 })
+  }
+}

--- a/src/lib/knowledge-graph.ts
+++ b/src/lib/knowledge-graph.ts
@@ -84,6 +84,30 @@ export class KnowledgeGraphService {
       await s.close()
     }
   }
+
+  async getSessions(): Promise<ChatSession[]> {
+    const s = this.getSession()
+    try {
+      const res = await s.run(
+        `MATCH (sess:Session)
+         OPTIONAL MATCH (sess)-[:HAS_MESSAGE]->(m:Message)
+         RETURN sess.id AS id, sess.title AS title,
+                sess.createdAt AS createdAt, sess.updatedAt AS updatedAt,
+                count(m) AS messageCount
+         ORDER BY sess.updatedAt DESC`
+      )
+      return res.records.map(r => ({
+        id: r.get('id'),
+        title: r.get('title'),
+        messages: [],
+        messageCount: r.get('messageCount').toNumber ? r.get('messageCount').toNumber() : r.get('messageCount'),
+        createdAt: new Date(r.get('createdAt')),
+        updatedAt: new Date(r.get('updatedAt'))
+      }))
+    } finally {
+      await s.close()
+    }
+  }
 }
 
 let kg: KnowledgeGraphService | null = null


### PR DESCRIPTION
## Summary
- hook up Neo4j service in `ChatHistoryDatabase`
- sync sessions and messages into the graph
- expose `/api/knowledge-graph` for querying stored sessions

## Testing
- `npm run type-check`
- `npm run dev` (fails to start chat API due to missing DeepSeek key)
- `curl -X POST http://localhost:9000/api/chat-history ...` -> created session
- `curl http://localhost:9000/api/knowledge-graph` -> returns error (Neo4j not running)


------
https://chatgpt.com/codex/tasks/task_e_68431b857a4c8320b5ee6013c112a96e